### PR TITLE
Implemented function for stopping motors by a different instance than the one currently controling motors

### DIFF
--- a/motor.c
+++ b/motor.c
@@ -119,7 +119,7 @@ void motor_wait_idle()
     printf("motor moving, state is %i , waiting...\n", busystate);  
     usleep(100000);   
   }
-  printf("freed from loop, motor state is %i ",busystate);
+  printf("Finished moving, motor state is %i ",busystate);
       
 }
 
@@ -282,7 +282,8 @@ int main(int argc, char *argv[])
       break;
     case 'm': // expose motor busy function
       int busycmd = busyexposed(stepspeed);
-      printf ("motor state is %i\n", busycmd);
+      //printf ("motor state is %i\n", busycmd);  // human readable, disabling as it only works for tshoot
+      return busycmd;
       break;
     default:
       printf("Invalid Argument %c\n", c);


### PR DESCRIPTION
Implemented function for stopping motors by a different instance than the one currently controlling motors.
Wait function checks for the existence of a shared memory object called STOP which is created when motors -d s is called.
The object itself is not actually written to.