### PR TITLE
Changed printing behavior and cleaned up stopping function

### DIFF
--- a/motor-daemon.c
+++ b/motor-daemon.c
@@ -1,0 +1,367 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+#include <syslog.h>
+#include <errno.h>
+#include <string.h>
+
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+
+
+#define SV_SOCK_PATH "/tmp/motors"
+#define MAX_CONN 5
+#define MOTOR_MOVE_STOP 0x0
+#define MOTOR_MOVE_RUN 0x1
+
+/* directional_attr */
+#define MOTOR_DIRECTIONAL_UP 0x0
+#define MOTOR_DIRECTIONAL_DOWN 0x1
+#define MOTOR_DIRECTIONAL_LEFT 0x2
+#define MOTOR_DIRECTIONAL_RIGHT 0x3
+
+#define MOTOR1_MAX_SPEED 1000
+#define MOTOR1_MIN_SPEED 10
+
+/* ioctl cmd */
+#define MOTOR_STOP 0x1
+#define MOTOR_RESET 0x2
+#define MOTOR_MOVE 0x3
+#define MOTOR_GET_STATUS 0x4
+#define MOTOR_SPEED 0x5
+#define MOTOR_GOBACK 0x6
+#define MOTOR_CRUISE 0x7
+
+enum motor_status
+{
+  MOTOR_IS_STOP,
+  MOTOR_IS_RUNNING,
+};
+
+struct request{
+    char command; // d,r,s,p,b (move, reset,set speed,get position, is busy)
+    char type;   // g,h,c (absolute,relative,cruise,stop)
+    int x;
+    int got_x;
+    int y;
+    int got_y;
+};
+
+struct response_position{
+    int x;     //for -p and other status commands
+    int y;    
+};
+
+struct motor_status_st
+{
+  int directional_attr;
+  int total_steps;
+  int current_steps;
+  int min_speed;
+  int cur_speed;
+  int max_speed;
+  int move_is_min;
+  int move_is_max;
+};
+
+struct motor_message
+{
+  int x;
+  int y;
+  enum motor_status status;
+  int speed;
+  /* these two members are not standard from the original kernel module */
+  unsigned int x_max_steps;
+  unsigned int y_max_steps;
+};
+
+struct motors_steps
+{
+  int x;
+  int y;
+};
+
+struct motor_reset_data
+{
+  unsigned int x_max_steps;
+  unsigned int y_max_steps;
+  unsigned int x_cur_step;
+  unsigned int y_cur_step;
+};
+
+
+
+int motorfd = -1;
+struct request request_message; // object for IPC request from client
+
+void motor_ioctl(int cmd, void *arg)
+{
+  //basically exists to not pass around the motor FD
+  ioctl(motorfd, cmd, arg);
+}
+
+void motor_status_get(struct motor_message *msg)
+{
+  motor_ioctl(MOTOR_GET_STATUS, msg);
+}
+
+void motor_get_maxsteps(unsigned int *maxx, unsigned int *maxy)
+{
+  struct motor_message msg;
+  motor_status_get(&msg);
+  if (maxx)
+    *maxx = msg.x_max_steps;
+  if (maxy)
+    *maxy = msg.y_max_steps;
+}
+
+int motor_is_busy()
+{
+  struct motor_message msg;
+  motor_status_get(&msg);
+  return msg.status == MOTOR_IS_RUNNING ? 1 : 0;
+}
+void motor_steps(int xsteps, int ysteps, int stepspeed)
+{
+  struct motors_steps steps;
+  steps.x = xsteps;
+  steps.y = ysteps;
+
+  
+  syslog(LOG_NOTICE," -> steps, X %d, Y %d, speed %d\n", steps.x, steps.y, stepspeed);
+  motor_ioctl(MOTOR_SPEED, &stepspeed);
+  motor_ioctl(MOTOR_MOVE, &steps);
+}
+
+void motor_set_position(int xpos, int ypos, int stepspeed)
+{
+  struct motor_message msg;
+  motor_status_get(&msg);
+
+  int deltax = xpos - msg.x;
+  int deltay = ypos - msg.y;
+
+  
+  syslog(LOG_NOTICE," -> set position current X: %d, Y: %d, steps required X: %d, Y: %d, speed %d\n", msg.x, msg.y, deltax, deltay, stepspeed);
+  motor_steps(deltax, deltay, stepspeed); 
+}
+
+
+
+
+static void daemonsetup()
+{
+    pid_t pid;
+
+    /* Fork off the parent process */
+    pid = fork();
+
+    /* An error occurred */
+    if (pid < 0)
+        exit(EXIT_FAILURE);
+
+    /* Success: Let the parent terminate */
+    if (pid > 0)
+        exit(EXIT_SUCCESS);
+
+    /* On success: The child process becomes session leader */
+    if (setsid() < 0)
+        exit(EXIT_FAILURE);
+
+    /* Catch, ignore and handle signals */
+    //TODO: Implement a working signal handler */
+    signal(SIGCHLD, SIG_IGN);
+    signal(SIGHUP, SIG_IGN);
+
+    /* Fork off for the second time*/
+    pid = fork();
+
+    /* An error occurred */
+    if (pid < 0)
+        exit(EXIT_FAILURE);
+
+    /* Success: Let the parent terminate */
+    if (pid > 0)
+        exit(EXIT_SUCCESS);
+
+    /* Set new file permissions */
+    umask(0);
+
+    /* Change the working directory to the root directory */
+    /* or another appropriated directory */
+    chdir("/tmp/");
+
+    /* Close all open file descriptors */
+    int x;
+    for (x = sysconf(_SC_OPEN_MAX); x>=0; x--)
+    {
+        close (x);
+    }
+
+    /* Open the log file */
+    openlog ("motors-daemon", LOG_PID, LOG_DAEMON);
+}
+
+void requestcleanup(){
+    //
+    request_message.command = 'd';
+    request_message.type = 's';
+    request_message.x = 0;
+    request_message.got_x = 0;
+    request_message.y = 0;
+    request_message.got_y = 0;
+}
+
+int main()
+{
+    daemonsetup();
+    int daemonstop = 0;
+    int stepspeed =900; //TODO move this value to a struct
+    //struct instances
+    struct sockaddr_un addr; //socket struct
+    struct motor_reset_data motor_reset_data;
+    struct motor_message pos;
+
+    //acquire control of motor device and perform a reset
+    motorfd = open("/dev/motor", 0);
+
+    //reset motor as setup
+    syslog(LOG_NOTICE,"== Reset position, please wait");
+    memset(&motor_reset_data, 0, sizeof(motor_reset_data));
+    ioctl(motorfd, MOTOR_RESET, &motor_reset_data);
+
+
+    int serverfd = socket(AF_UNIX, SOCK_STREAM, 0);
+    syslog(LOG_NOTICE,"Server socket fd = %d", serverfd);
+    //check if we could acquire fd for socket
+    if (serverfd == -1){
+        syslog (LOG_ERR, "Error initializing the socket, could not get a proper fd");
+        closelog();
+        exit(EXIT_FAILURE);
+    }
+
+    //cleanup for socket path if path already exists
+    if (remove(SV_SOCK_PATH) == -1 && errno != ENOENT) {
+        syslog(LOG_ERR,"could not remove-%s, exiting", SV_SOCK_PATH);
+        closelog();
+        exit(EXIT_FAILURE);
+    }
+
+    memset(&addr, 0, sizeof(struct sockaddr_un));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, SV_SOCK_PATH, sizeof(addr.sun_path) - 1);
+    //binding to socket
+    if (bind(serverfd, (struct sockaddr *) &addr, sizeof(struct sockaddr_un)) == -1) {
+        syslog(LOG_ERR,"Error binding to socket, exiting");
+        closelog();
+        exit(EXIT_FAILURE);
+    }
+
+    //start listening on socket
+    if (listen(serverfd, MAX_CONN) == -1) {
+        closelog();
+        exit(EXIT_FAILURE);
+    }
+
+    syslog (LOG_NOTICE, "motors-daemon started");
+
+
+    while (daemonstop == 0)
+    {   
+        //make request object go back to initial value
+        requestcleanup();
+        syslog(LOG_NOTICE,"Waiting to accept a connection");
+        //blocking code, wait for a connection
+        int clientfd = accept(serverfd, NULL, NULL);
+        syslog(LOG_NOTICE,"Accepting a connection\n");
+
+        //load the message onto the reques_message struct
+        if(read(clientfd,&request_message,sizeof(struct request)) == -1){
+            syslog (LOG_NOTICE, "Could not read message from motors app, ignore request");
+        }
+        else{
+            switch(request_message.command){
+                case 'd': // move direction
+                    switch(request_message.type){
+                    case 'g': //relative movement
+                        motor_steps(request_message.x, request_message.y, stepspeed);
+                        break;
+                    case 'h': // absolute movement
+                            motor_status_get(&pos);
+                            if (request_message.got_x == 0)
+                              request_message.x = pos.x; //as we are rewriting initial between requests this should not be necessary but leaving as is as to not break anything
+                            if (request_message.got_y == 0)
+                              request_message.y = pos.y;
+                            motor_set_position(request_message.x, request_message.y, stepspeed);
+                        break;
+                    case 'b': // go back
+                        motor_ioctl(MOTOR_GOBACK, NULL);//should we block until "go back" movement is finished?
+                    break;
+                    case 'c': // cruise
+                        motor_ioctl(MOTOR_CRUISE, NULL);
+                    break;
+                    case 's': // stop
+                        motor_ioctl(MOTOR_STOP, NULL);
+                    break;
+
+                    }
+                break;
+                case 'r': //reset
+                syslog (LOG_NOTICE, "executing reset...");
+                //cleanup of reset data before reset, is necesary otherwise reset is never performed even though it never fails
+                memset(&motor_reset_data, 0, sizeof(motor_reset_data));
+                int reset = ioctl(motorfd, MOTOR_RESET, &motor_reset_data);
+                break;
+                case 'i': //get initial parameters
+                
+
+                break;
+                case 'j': //get json
+
+                break;
+                case 'p': //get simple x y position 
+
+                break;
+                case 'b': //is busy
+
+                break;
+                case 's': //set speed
+                if (request_message.x > 900){
+                    stepspeed = 900;
+                  }
+                else{
+                    stepspeed = request_message.x; //if command is s, we use the x variable so we dont define a new variable inside struct so object size is smaller
+                  }
+
+                break;
+                case 'S': //show status
+
+                break;
+
+                
+            }
+
+        }
+
+
+        syslog (LOG_NOTICE, "request command is %c",request_message.command);
+        syslog (LOG_NOTICE, "request type is %c",request_message.type);
+        syslog (LOG_NOTICE, "request x is %i",request_message.x);
+        syslog (LOG_NOTICE, "request y is %i",request_message.y);
+        syslog (LOG_NOTICE, "====================");
+        motor_status_get(&pos);
+        syslog (LOG_NOTICE, "final absolute coordinates are %i,%i",pos.x,pos.y);
+        //break;
+    }
+
+    syslog (LOG_NOTICE, "motors-daemon terminated.");
+    closelog();
+
+    return EXIT_SUCCESS;
+}

--- a/motor.c
+++ b/motor.c
@@ -10,32 +10,27 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <string.h>
 
-#define MOTOR_MOVE_STOP 0x0
-#define MOTOR_MOVE_RUN 0x1
 
-/* directional_attr */
-#define MOTOR_DIRECTIONAL_UP 0x0
-#define MOTOR_DIRECTIONAL_DOWN 0x1
-#define MOTOR_DIRECTIONAL_LEFT 0x2
-#define MOTOR_DIRECTIONAL_RIGHT 0x3
-
-#define MOTOR1_MAX_SPEED 1000
-#define MOTOR1_MIN_SPEED 10
-
-/* ioctl cmd */
-#define MOTOR_STOP 0x1
-#define MOTOR_RESET 0x2
-#define MOTOR_MOVE 0x3
-#define MOTOR_GET_STATUS 0x4
-#define MOTOR_SPEED 0x5
-#define MOTOR_GOBACK 0x6
-#define MOTOR_CRUISE 0x7
+#define SV_SOCK_PATH "/tmp/motors"
+#define BUF_SIZE 15
 
 enum motor_status
 {
   MOTOR_IS_STOP,
   MOTOR_IS_RUNNING,
+};
+
+struct request{
+    char command; // d,r,s,p,b,S,i,j (move, reset,set speed,get position, is busy,Status,initial,JSON)
+    char type;   // g,h,c,s (absolute,relative,cruise,stop)
+    int x;
+    int got_x;
+    int y;
+    int got_y;
 };
 
 struct motor_message
@@ -49,322 +44,169 @@ struct motor_message
   unsigned int y_max_steps;
 };
 
-struct motors_steps
-{
-  int x;
-  int y;
-};
-
-struct motor_move_st
-{
-  int motor_directional;
-  int motor_move_steps;
-  int motor_move_speed;
-};
-struct motor_status_st
-{
-  int directional_attr;
-  int total_steps;
-  int current_steps;
-  int min_speed;
-  int cur_speed;
-  int max_speed;
-  int move_is_min;
-  int move_is_max;
-};
-
-struct motor_reset_data
-{
-  unsigned int x_max_steps;
-  unsigned int y_max_steps;
-  unsigned int x_cur_step;
-  unsigned int y_cur_step;
-};
-
-int fd = -1;
-bool debugflag = false;
-/* shared memory file descriptor for stop procedure*/
-int stop_fd;
-const int STOP_SHARED_SIZE = 1;
-const char* SHD_NAME = "STOP";
-
-void debugprintf(const char * string, ... )
-{
-  if(debugflag){
-      printf(string);
-    }   
-}
-
-void motor_ioctl(int cmd, void *arg)
-{
-  // printf("[IOCTL] %d, %p\n", cmd, arg);
-  ioctl(fd, cmd, arg);
-}
-
-void motor_status_get(struct motor_message *msg)
-{
-  motor_ioctl(MOTOR_GET_STATUS, msg);
-}
-
-void motor_get_maxsteps(unsigned int *maxx, unsigned int *maxy)
-{
-  struct motor_message msg;
-  motor_status_get(&msg);
-  if (maxx)
-    *maxx = msg.x_max_steps;
-  if (maxy)
-    *maxy = msg.y_max_steps;
-}
-
-int motor_is_busy()
-{
-  struct motor_message msg;
-  motor_status_get(&msg);
-  return msg.status == MOTOR_IS_RUNNING ? 1 : 0;
-}
-
-void motor_wait_idle()
-{ 
-  int busystate=motor_is_busy();
-  while (busystate)
-  { 
-    busystate = motor_is_busy();
-    debugprintf("motor moving, state is %i , waiting...\n", busystate);
-    usleep(100000);
-    //check if shared memory object created by a stop call exists
-    if (shm_open(SHD_NAME, O_RDONLY, 0666) == -1){
-       debugprintf("shared memory called %s could not be open, must not exist, continue waiting for another loop\n",SHD_NAME);
-    }
-    else{
-       debugprintf("shared memory called %s exists! stopping movement\n",SHD_NAME);
-       busystate = 0;
-    } 
-  }
-  int unlink = shm_unlink(SHD_NAME); //necesary for object to be completely destroyed and not to trigger stop next time a movement is requested
-  //TODO actually write to and read from the memory object so we dont have to create/delete it everytime we want to move
-  debugprintf("Finished moving, motor state is %i ",busystate);  
-    
-}
-
-void motor_steps(int xsteps, int ysteps, int stepspeed)
-{
-  struct motors_steps steps;
-  steps.x = xsteps;
-  steps.y = ysteps;
-
-  
-  debugprintf(" -> steps, X %d, Y %d, speed %d\n", steps.x, steps.y, stepspeed);
-  motor_ioctl(MOTOR_SPEED, &stepspeed);
-  motor_ioctl(MOTOR_MOVE, &steps);
-
-  motor_wait_idle();
-}
-
-void device_busychk(){         //should only be called after /dev/motor open(), checks the if we could acquire the file descriptor, if not halts the program inmediately
-  if (fd == -1){
-  	debugprintf("could not get access to motor device, most likely is busy\n");
-  	exit(EXIT_FAILURE);
-    }
-}
-
-
-int stop_set(){
-    //create a shared memory object 
-    void* ptr;
-    stop_fd = shm_open(SHD_NAME, O_CREAT | O_RDWR, 0666);    
-    if(stop_fd == -1){
-    	debugprintf("getting fd of shared memory while failed, errno is %i motors most likely wont stop!\n", errno);
-    }
-    else{
-    	debugprintf("open on stop set happened, fd is %i \n",stop_fd);
-    }
-    ftruncate(stop_fd, STOP_SHARED_SIZE);
-    ptr = mmap(NULL, STOP_SHARED_SIZE, PROT_WRITE | PROT_WRITE, MAP_SHARED, stop_fd, 0);
-    debugprintf("shared memory called %s should be created by now\n", SHD_NAME);
-
-}
-
-
-int stop_function(){
-    if (fd == -1){
-    	 stop_set(); //stop_set creates a shared memory object we use as a flag to tell another instance we are requesting to stop
-            
-	     while(open("/dev/motor", 0) == -1){
-	     	debugprintf("stop called, device is still inaccessible, move function still needs to check for stop flag, sleeping...\n");
-	     	usleep(100000);
-	     }
-	     debugprintf("could read /dev/motor device should be free, resetting stop flag \n");
-	     int unlink = shm_unlink(SHD_NAME);
-
-    }
-    else{
-       printf("current instance of the motors app has control over device, nothing to stop\n");
-    }
-}
-
-
-void motor_set_position(int xpos, int ypos, int stepspeed)
-{
-  struct motor_message msg;
-  motor_status_get(&msg);
-
-  int deltax = xpos - msg.x;
-  int deltay = ypos - msg.y;
-
-  
-  debugprintf(" -> set position current X: %d, Y: %d, steps required X: %d, Y: %d, speed %d\n", msg.x, msg.y, deltax, deltay, stepspeed);
-  motor_steps(deltax, deltay, stepspeed);
-
-  motor_wait_idle();
-}
-
-void show_status()
-{
-  unsigned int maxx, maxy;
-  struct motor_message steps;
-
-  motor_get_maxsteps(&maxx, &maxy);
-  printf("Max X Steps %d.\n", maxx);
-  printf("Max Y Steps %d.\n", maxy);
-
-  motor_status_get(&steps);
-  printf("Status Move: %d.\n", steps.status);
-  printf("X Steps %d.\n", steps.x);
-  printf("Y Steps %d.\n", steps.y);
-  printf("Speed %d.\n", steps.speed);
-}
-
-void JSON_status()
-{
-  // return xpos,ypos and status in JSON string
-  // allows passing straight back to async call from ptzclient.cgi
-  // with little effort and ability to track x,y position
-  struct motor_message steps;
-
-  motor_status_get(&steps);
-  printf("{");
-  printf("\"status\":\"%d\"", steps.status);
-  printf(",");
-  printf("\"xpos\":\"%d\"", steps.x);
-  printf(",");
-  printf("\"ypos\":\"%d\"", steps.y);
-  printf(",");
-  printf("\"speed\":\"%d\"", steps.speed);
-  printf("}");
-}
-
-void xy_pos()
-{
-  // return xpos,ypos as a string
-  struct motor_message steps;
-
-  motor_status_get(&steps);
-  printf("%d,%d", steps.x, steps.y);
-}
-
-void JSON_initial()
+void JSON_initial(struct motor_message *message)
 {
   // return all known parameters in JSON string
   // idea is when client page loads in browser we
   // get current details from camera
-  struct motor_message steps;
-  unsigned int maxx, maxy;
-
-  motor_status_get(&steps);
   printf("{");
-  printf("\"status\":\"%d\"", steps.status);
+  printf("\"status\":\"%d\"", (*message).status);
   printf(",");
-  printf("\"xpos\":\"%d\"", steps.x);
+  printf("\"xpos\":\"%d\"", (*message).x);
   printf(",");
-  printf("\"ypos\":\"%d\"", steps.y);
-
-  motor_get_maxsteps(&maxx, &maxy);
+  printf("\"ypos\":\"%d\"", (*message).y);
   printf(",");
-  printf("\"xmax\":\"%d\"", maxx);
+  printf("\"xmax\":\"%d\"", (*message).x_max_steps);
   printf(",");
-  printf("\"ymax\":\"%d\"", maxy);
+  printf("\"ymax\":\"%d\"", (*message).y_max_steps);
   printf(",");
-  printf("\"speed\":\"%d\"", steps.speed);
-
+  printf("\"speed\":\"%d\"", (*message).speed);
   printf("}");
 }
+
+void JSON_status(struct motor_message *message)
+{
+  // return xpos,ypos and status in JSON string
+  // allows passing straight back to async call from ptzclient.cgi
+  // with little effort and ability to track x,y position
+  printf("{");
+  printf("\"status\":\"%d\"", (*message).status);
+  printf(",");
+  printf("\"xpos\":\"%d\"", (*message).x);
+  printf(",");
+  printf("\"ypos\":\"%d\"", (*message).y);
+  printf(",");
+  printf("\"speed\":\"%d\"", (*message).speed);
+  printf("}");
+}
+
+void xy_pos(struct motor_message *message)
+{
+  printf("%d,%d", (*message).x, (*message).y);
+}
+
+void show_status(struct motor_message *message)
+{
+  printf("Max X Steps %d.\n", (*message).x_max_steps);
+  printf("Max Y Steps %d.\n", (*message).y_max_steps);
+  printf("Status Move: %d.\n", (*message).status);
+  printf("X Steps %d.\n", (*message).x);
+  printf("Y Steps %d.\n",(*message).y);
+  printf("Speed %d.\n", (*message).speed);
+}
+
 
 int main(int argc, char *argv[])
 {
   char direction = 's';
   int stepspeed = 900;
-  int xpos = 0;
-  int ypos = 0;
-  int got_x = 0;
-  int got_y = 0;
   int c;
+  struct request request_message;
+  request_message.got_x = 0;
+  request_message.got_y = 0;
+ 
+  //should open socket here
+  struct sockaddr_un addr;
+ 
+  int serverfd = socket(AF_UNIX, SOCK_STREAM, 0);
+
+  if (serverfd == -1) {
+      exit(EXIT_FAILURE);
+    }
+  memset(&addr, 0, sizeof(struct sockaddr_un));
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, SV_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+  //connect to the socket
+  if (connect(serverfd, (struct sockaddr *) &addr,sizeof(struct sockaddr_un)) == -1)
+      exit(EXIT_FAILURE);
   
-  struct motor_message pos;
 
-  fd = open("/dev/motor", 0); // T31 sources don't take into account the open mode
-  debugprintf("fd for /dev/motor is %i \n", fd);  
-
+  
+ 
   while ((c = getopt(argc, argv, "d:s:x:y:b:jipSrv")) != -1)
   {
     switch (c)
     {
     case 'd':
+      request_message.command = 'd';
       direction = optarg[0];
       break;
     case 's':
-      device_busychk();
+      request_message.command = 's';
       if (atoi(optarg) > 900)
       {
-        stepspeed = 900;
+        request_message.x = 900;
       }
       else
       {
-        stepspeed = atoi(optarg);
+        request_message.x = atoi(optarg);
       }
-
+      write(serverfd,&request_message,sizeof(struct request));
       break;
     case 'x':
-      device_busychk();
-      xpos = atoi(optarg);
-      got_x = 1;
+      request_message.x = atoi(optarg);
+      request_message.got_x = 1;
       break;
     case 'y':
-      device_busychk();
-      ypos = atoi(optarg);
-      got_y = 1;
+      request_message.y = atoi(optarg);
+      request_message.got_y = 1;
       break;
     case 'j':
-      // get x and y current positions and status
-      JSON_status();
-      exit(EXIT_SUCCESS);
+      request_message.command = 'j';
+      write(serverfd,&request_message,sizeof(struct request));
+
+      struct motor_message status;
+      read(serverfd,&status,sizeof(struct motor_message));
+ 	  JSON_status(&status);
       break;
     case 'i':
       // get all initial values
-      JSON_initial();
-      exit(EXIT_SUCCESS);
+      request_message.command = 'i';
+      write(serverfd,&request_message,sizeof(struct request));
+      
+      struct motor_message initial;
+      read(serverfd,&initial,sizeof(struct motor_message));
+
+      JSON_initial(&initial);
       break;
     case 'p':
-      // get x and y current positions
-      xy_pos();
-      exit(EXIT_SUCCESS);
+      request_message.command = 'p';
+      write(serverfd,&request_message,sizeof(struct request));
+      
+      struct motor_message pos;
+      read(serverfd,&pos,sizeof(struct motor_message));
+
+      xy_pos(&pos);
       break;
     case 'v':
-      debugflag = true;
+      //not printing any debug on the app yet,daemon prints on logread
+      //debugflag = true;
       break;
     case 'r': // reset
-      device_busychk();
-      debugprintf(" == Reset position, please wait\n");
-      struct motor_reset_data motor_reset_data;
-      memset(&motor_reset_data, 0, sizeof(motor_reset_data));
-      ioctl(fd, MOTOR_RESET, &motor_reset_data);
+      request_message.command = 'r';
       break;
     case 'S': // status
-      show_status();
+      request_message.command = 'S';
+      write(serverfd,&request_message,sizeof(struct request));
+      
+      struct motor_message stat;
+      read(serverfd,&stat,sizeof(struct motor_message));
+
+      show_status(&stat);
       break;
     case 'b': // is moving?
-      //program exits with failure (1) if motors are moving and with success (0) if they are not currently doesnt print anything, will adjuts if needed
-      device_busychk();
-      exit(EXIT_SUCCESS);
+      request_message.command = 'b';
+      write(serverfd,&request_message,sizeof(struct request));
+      
+      struct motor_message busy;
+      read(serverfd,&busy,sizeof(struct motor_message));
+      	if(busy.status == MOTOR_IS_RUNNING){
+      		return(1);
+      	}
+      	else{
+      		return(0);
+      	}
       break;
     default:
       printf("Invalid Argument %c\n", c);
@@ -388,41 +230,28 @@ int main(int argc, char *argv[])
   switch (direction)
   {
   case 's': // stop
-    if(fd == -1){ 
-        //current instance doesnt have control of motor device, need to set flag requesting to do it
-        stop_function();
-    }
-    else{
-        //we have control of motor device, usually when reset is called
-        motor_ioctl(MOTOR_STOP, NULL);
-    }
+  	request_message.type = 's';
+  	write(serverfd,&request_message,sizeof(struct request));
     break;
 
   case 'c': // cruise
-    motor_ioctl(MOTOR_CRUISE, NULL);
-    motor_wait_idle();
+  	request_message.type = 'c';
+  	write(serverfd,&request_message,sizeof(struct request));
     break;
 
   case 'b': // go back
-    motor_status_get(&pos);
-    debugprintf("Going from X %d, Y %d...\n", pos.x, pos.y);
-    motor_ioctl(MOTOR_GOBACK, NULL);
-    motor_wait_idle();
-    motor_status_get(&pos);
-    debugprintf("To X %d, Y %d...\n", pos.x, pos.y);
+  	request_message.type = 'b';
+  	write(serverfd,&request_message,sizeof(struct request));
     break;
 
-  case 'h': // set position
-    motor_status_get(&pos);
-    if (got_x == 0)
-      xpos = pos.x;
-    if (got_y == 0)
-      ypos = pos.y;
-    motor_set_position(xpos, ypos, stepspeed);
+  case 'h': // set position (absolute movement)
+  	request_message.type = 'h';
+  	write(serverfd,&request_message,sizeof(struct request));
     break;
 
-  case 'g': // x y steps
-    motor_steps(xpos, ypos, stepspeed);
+  case 'g': // move x y (relative movement)
+    request_message.type = 'g';
+    write(serverfd,&request_message,sizeof(struct request));
     break;
 
   default:
@@ -436,5 +265,6 @@ int main(int argc, char *argv[])
            argv[0]);
     exit(EXIT_FAILURE);
   }
+
   return 0;
 }

--- a/motor.c
+++ b/motor.c
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
 
   
  
-  while ((c = getopt(argc, argv, "d:s:x:y:b:jipSrv")) != -1)
+  while ((c = getopt(argc, argv, "d:s:x:y:jipSrvb")) != -1)
   {
     switch (c)
     {
@@ -202,9 +202,11 @@ int main(int argc, char *argv[])
       struct motor_message busy;
       read(serverfd,&busy,sizeof(struct motor_message));
       	if(busy.status == MOTOR_IS_RUNNING){
+      		printf("1\n");
       		return(1);
       	}
       	else{
+      		printf("0\n");
       		return(0);
       	}
       break;
@@ -220,7 +222,7 @@ int main(int argc, char *argv[])
              "\t -j return json string xpos,ypos,status.\n"
              "\t -i return json string for all camera parameters\n"
              "\t -p return xpos,ypos as a string\n"
-             "\t -b exits program with 1 if motor is (b)usy moving or 0 if is not (no printable output)\n" //...yet, can add it if needed by onvif
+             "\t -b prints 1 if motor is (b)usy moving or 0 if is not\n"
              "\t -S show status\n",
              argv[0]);
       exit(EXIT_FAILURE);


### PR DESCRIPTION
Now -v is needed for printing debugging information except for j,i,p,S options which print by default. 
Also implemented (and cleaned up from previous PR) stopping function by checking the prescence of a shared memory object between each moving/waiting loop.