### PR TITLE
set speed even if no move is requested

### DIFF
--- a/motor-daemon.c
+++ b/motor-daemon.c
@@ -467,6 +467,7 @@ int main(int argc, char *argv[])
                     else{
                         last_known_speed = request_message.speed;
                     }
+                    motor_ioctl(MOTOR_SPEED, &last_known_speed);
                     syslog(LOG_DEBUG, "Set speed command, last known speed now %d", last_known_speed);
                 break;
                 case 'I': // Invert motor direction


### PR DESCRIPTION
Pass the last_known_speed to the kernel module whenever it is specified. This is done so that a `motors -s <speed>` sets the speed without having to specify a move as well via `-d ...`.